### PR TITLE
fix: fix overlap issues

### DIFF
--- a/dmconvert/normal/danmaku_array.py
+++ b/dmconvert/normal/danmaku_array.py
@@ -13,7 +13,7 @@ class DanmakuArray:
         self.solution_y = solution_y
         self.font_size = font_size
         self.rows = int(solution_y / font_size)
-        self.time_length_array = [[0, 0] for _ in range(self.rows)]
+        self.time_length_array = [[-1, 0] for _ in range(self.rows)]
 
     def set_time_length(self, row, time, length):
         """Set time and length for a row"""

--- a/dmconvert/normal/normal_handler.py
+++ b/dmconvert/normal/normal_handler.py
@@ -11,7 +11,7 @@ def get_position_y(font_size, appear_time, text_length, resolution_x, roll_time,
     best_bias = float("-inf")
     for i in range(array.rows):
         previous_appear_time = array.get_time(i)
-        if previous_appear_time == 0:
+        if previous_appear_time < 0:
             array.set_time_length(i, appear_time, text_length)
             return 1 + i * font_size
         previous_length = array.get_length(i)
@@ -21,7 +21,7 @@ def get_position_y(font_size, appear_time, text_length, resolution_x, roll_time,
         # The initial difference length
         delta_x = (appear_time - previous_appear_time) * previous_velocity - (
             previous_length + text_length
-        ) / 2
+        ) * 1.5
         # If the initial difference length is negative, which means overlapped. Skip.
         if delta_x < 0:
             continue
@@ -46,7 +46,7 @@ def get_fixed_y(font_size, appear_time, resolution_y, array):
     best_bias = -1
     for i in range(array.rows):
         previous_appear_time = array.get_time(i)
-        if previous_appear_time == 0:
+        if previous_appear_time < 0:
             array.set_time_length(i, appear_time, 0)
             return resolution_y - font_size * (i + 1) + 1
         else:


### PR DESCRIPTION
## Description

Fix the overlap issue for those with a start time of 0 and some rightto left (R2L) danmakus.

Danmakus with a start time of 0 are likely due to the initial value in the array being 0. This causes subsequent danmakus to overwrite the positions of previous ones.

Regarding the overlap issues of R2L danmakus, I suspect they are caused by the inaccuracy of the `get_str_len` function.


## Who Can Review?

@timerring 

## TODO

- [ ] Rewrite the `get_str_len` function.

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
