### PR TITLE
fix: refactor text length function

### DIFF
--- a/dmconvert/convert.py
+++ b/dmconvert/convert.py
@@ -27,5 +27,5 @@ def convert_xml_to_ass(font_size, resolution_x, resolution_y, xml_file, ass_file
 
 if __name__ == "__main__":
     xml_file = "sample.xml"
-    ass_file = "converted.ass"
+    ass_file = "sample.ass"
     convert_xml_to_ass(38, 720, 1280, xml_file, ass_file)

--- a/dmconvert/normal/normal_handler.py
+++ b/dmconvert/normal/normal_handler.py
@@ -21,7 +21,7 @@ def get_position_y(font_size, appear_time, text_length, resolution_x, roll_time,
         # The initial difference length
         delta_x = (appear_time - previous_appear_time) * previous_velocity - (
             previous_length + text_length
-        ) * 1.5
+        ) / 2
         # If the initial difference length is negative, which means overlapped. Skip.
         if delta_x < 0:
             continue

--- a/dmconvert/utils.py
+++ b/dmconvert/utils.py
@@ -12,38 +12,16 @@ def format_time(seconds):
     return f"{hours}:{minutes:02d}:{seconds:02d}.{centiseconds:02d}"
 
 
-def is_utf8(s):
-    try:
-        s.decode("utf-8")
-        return True
-    except UnicodeDecodeError:
-        return False
-
-
-def get_str_len(s, fontSizeSet):
-    if s is None:
-        return -1
-
-    if isinstance(s, bytes):
-        str_bytes = s
-    else:
-        str_bytes = s.encode("utf-8")
-
-    if is_utf8(str_bytes):
-        cnt = 0
-        index = 0
-        while index < len(str_bytes):
-            byte = str_bytes[index]
-            if byte >= 0xC0:
-                cnt += 1
-            elif byte < 0x80:
-                cnt += 1
-            index += 1
-    else:
-        cnt = len(str_bytes)
-
-    len_result = cnt * int((fontSizeSet) / 1.2)
-    return len_result
+def get_str_len(text, fontSizeSet):
+    width = 0
+    for char in text:
+        if ord(char) > 0x2E80: # chinese char
+            width += 2
+        elif char in '[](){}「」【】《》':
+            width += 2
+        else:
+            width += 1
+    return width * (fontSizeSet/2)
 
 
 def get_color(price):


### PR DESCRIPTION
## Description

Refactor the `get_str_len` function to fix the overlap issue of R2L danmaku.

## Related Issues

#19 

## Who Can Review?

@timerring 

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
