### PR TITLE
fix: BTM render issue

### DIFF
--- a/dmconvert/normal/normal_handler.py
+++ b/dmconvert/normal/normal_handler.py
@@ -91,7 +91,7 @@ def draw_normal_danmaku(
             start_time = format_time(appear_time)
 
             # Format text
-            text = remove_emojis(d.text)
+            text = remove_emojis(d.text, ".")
 
             # For rolling danmakus (most common type)
             if danmaku_type == 1:


### PR DESCRIPTION
## Description

Sometimes the BTM danmaku will be rendered as the color code, after analysis, I find that due to the emojis are filtered and substituted by the space, so the ass file will recognize the color code as text. 

## Changes Proposed

Use the dot `.` to replace the space first, which will not affect the viewing experience.

## Who Can Review?

@timerring 

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
